### PR TITLE
Add support for chunked module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import path from 'path'
 const VITE_INTERNAL_ANALYSIS_PLUGIN = 'vite:build-import-analysis'
 const EXTERNAL_SCRIPT_RE = /<script[^<>]*['"]*src['"]*=['"]*([^ '"]+)['"]*[^<>]*><\/script>/g
 const EXTERNAL_CSS_RE = /<link[^<>]*['"]*rel['"]*=['"]*stylesheet['"]*[^<>]+['"]*href['"]*=['"]([^^ '"]+)['"][^<>]*>/g
+const EXTERNAL_MODULE_RE = /<link[^<>]*['"]*rel['"]*=['"]*modulepreload['"]*[^<>]+['"]*href['"]*=['"]([^^ '"]+)['"][^<>]*>/g;
 
 export type GenerateBundle = HookHandler<Plugin['generateBundle']>
 
@@ -90,6 +91,7 @@ export function sri (options?: { ignoreMissingAsset: boolean }): Plugin {
 
             html = await transformHTML(EXTERNAL_SCRIPT_RE, 10, name, html)
             html = await transformHTML(EXTERNAL_CSS_RE, 1, name, html)
+            html = await transformHTML(EXTERNAL_MODULE_RE, 1, name, html)
 
             chunk.source = html
           }


### PR DESCRIPTION
Because of the plugin `splitVendorChunkPlugin`, vendor files are generated

`<link rel="modulepreload" crossorigin href="/assets/vendor-BnDpVIbO.js">`

Added support to add integrity to them also
<img width="1662" alt="Screenshot 2024-03-28 at 09 30 13" src="https://github.com/yoyo930021/vite-plugin-sri3/assets/11539419/eec19e34-926a-4899-9c94-6d061673649a">
